### PR TITLE
Add functionality for ChatState

### DIFF
--- a/src/com/isode/stroke/chat/ChatStateTracker.java
+++ b/src/com/isode/stroke/chat/ChatStateTracker.java
@@ -1,0 +1,51 @@
+package com.isode.stroke.chat;
+
+import com.isode.stroke.elements.Message;
+import com.isode.stroke.elements.Presence;
+import com.isode.stroke.elements.ChatState;
+import com.isode.stroke.signals.Signal1;
+import com.isode.stroke.base.NotNull;
+
+public class ChatStateTracker {
+
+	private ChatState.ChatStateType currentState_;
+	public final Signal1<ChatState.ChatStateType> onChatStateChange = new Signal1<ChatState.ChatStateType>();
+
+	/**
+	* ChatStateTracker();
+	*/
+	public ChatStateTracker() {
+		currentState_ = ChatState.ChatStateType.Gone;
+	}
+
+	/**
+	* @param message, notnull
+	*/
+	public void handleMessageReceived(Message message) {
+		NotNull.exceptIfNull(message, "message");
+		if (message.getType() == Message.Type.Error) {
+			return;
+		}
+		ChatState statePayload = message.getPayload(new ChatState());
+		if (statePayload != null) {
+			changeState(statePayload.getChatState());
+		}
+	}
+
+	/**
+	* @param newPresence, notnull
+	*/
+	public void handlePresenceChange(Presence newPresence) {
+		NotNull.exceptIfNull(newPresence, "newPresence");
+		if (newPresence.getType() == Presence.Type.Unavailable) {
+			onChatStateChange.emit(ChatState.ChatStateType.Gone);
+		}
+	}
+
+	private void changeState(ChatState.ChatStateType state) {
+		if (state != currentState_) {
+			currentState_ = state;
+			onChatStateChange.emit(state);
+		}
+	}
+}

--- a/src/com/isode/stroke/elements/CapsInfo.java
+++ b/src/com/isode/stroke/elements/CapsInfo.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.elements;
 
 import com.isode.stroke.base.NotNull;

--- a/src/com/isode/stroke/elements/ChatState.java
+++ b/src/com/isode/stroke/elements/ChatState.java
@@ -1,0 +1,43 @@
+package com.isode.stroke.elements;
+
+import com.isode.stroke.base.NotNull;
+import com.isode.stroke.elements.Payload;
+
+public class ChatState extends Payload {
+
+	public enum ChatStateType {Active, Composing, Paused, Inactive, Gone};
+
+	private ChatStateType state_;
+	
+	/**
+	* ChatState();
+	*/
+	public ChatState() {
+		state_ = ChatStateType.Active;
+	}
+
+	/**
+	* ChatState(state);
+	*/
+	public ChatState(ChatStateType state) {
+		NotNull.exceptIfNull(state, "state");
+		state_ = state;
+	}
+
+	/**
+	*
+	* @return state, notnull.
+	*/
+	public ChatStateType getChatState() {
+		return state_;
+	}
+
+	/**
+	*
+	* @param state, notnull.
+	*/
+	public void setChatState(ChatStateType state) {
+		NotNull.exceptIfNull(state, "state");
+		state_ = state;
+	}
+}

--- a/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
+++ b/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.parser.payloadparsers;
 
 import com.isode.stroke.parser.GenericPayloadParser;

--- a/src/com/isode/stroke/parser/payloadparsers/ChatStateParser.java
+++ b/src/com/isode/stroke/parser/payloadparsers/ChatStateParser.java
@@ -1,0 +1,50 @@
+package com.isode.stroke.parser.payloadparsers;
+
+import com.isode.stroke.parser.GenericPayloadParser;
+import com.isode.stroke.parser.AttributeMap;
+import com.isode.stroke.elements.ChatState;
+import com.isode.stroke.base.NotNull;
+
+public class ChatStateParser extends GenericPayloadParser<ChatState> {
+
+	private int level_ = 0;
+
+	/**
+	* ChatStateParser();
+	*/
+	public ChatStateParser() {
+		super(new ChatState());
+	}
+
+	/**
+	* @param attributes, notnull.
+	*/
+	public void handleStartElement(String element, String ns, AttributeMap attributes) {
+		NotNull.exceptIfNull(element, "element");
+		if (this.level_ == 0) {
+			ChatState.ChatStateType state = ChatState.ChatStateType.Active;
+			if (element.equals("active")) {
+				state = ChatState.ChatStateType.Active;
+			} else if (element.equals("composing")) {
+				state = ChatState.ChatStateType.Composing;
+			} else if (element.equals("inactive")) {
+				state = ChatState.ChatStateType.Inactive;
+			} else if (element.equals("paused")) {
+				state = ChatState.ChatStateType.Paused;
+			} else if (element.equals("gone")) {
+				state = ChatState.ChatStateType.Gone;
+			}
+			getPayloadInternal().setChatState(state);
+		}
+		++level_;
+	}
+
+	public void handleEndElement(String element, String ns) {
+		--level_;
+	}
+
+	public void handleCharacterData(String data) {
+
+	}
+
+}

--- a/src/com/isode/stroke/parser/payloadparsers/ChatStateParserFactory.java
+++ b/src/com/isode/stroke/parser/payloadparsers/ChatStateParserFactory.java
@@ -1,0 +1,32 @@
+package com.isode.stroke.parser.payloadparsers;
+
+import com.isode.stroke.parser.PayloadParserFactory;
+import com.isode.stroke.parser.payloadparsers.ChatStateParser;
+import com.isode.stroke.parser.AttributeMap;
+import com.isode.stroke.parser.PayloadParser;
+
+public class ChatStateParserFactory implements PayloadParserFactory {
+
+	/**
+	* ChatStateParserFactory();
+	*/
+	public ChatStateParserFactory() {
+
+	}
+
+	/**
+	* @param attributes, notnull
+	*/
+	public boolean canParse(String element, String ns, AttributeMap attributes) {
+		return  ((ns == "http://jabber.org/protocol/chatstates") && 
+			(element == "active" || element == "composing" || element == "paused" || element == "inactive" || element == "gone"));
+	}
+
+	/**
+	* @return PayloadParser()
+	*/
+	public PayloadParser createPayloadParser() {
+		return (new ChatStateParser());
+	}
+}
+

--- a/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
+++ b/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
@@ -6,6 +6,11 @@
  * Copyright (c) 2010, Remko Tronçon.
  * All rights reserved.
  */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved. 
+ */
+
 package com.isode.stroke.parser.payloadparsers;
 
 import com.isode.stroke.parser.GenericPayloadParserFactory;

--- a/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
+++ b/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
@@ -47,7 +47,7 @@ public class FullPayloadParserFactoryCollection extends PayloadParserFactoryColl
 	//addFactory(new VCardUpdateParserFactory());
 	//addFactory(new VCardParserFactory());
 	//addFactory(new PrivateStorageParserFactory(this));
-	//addFactory(new ChatStateParserFactory());
+	addFactory(new ChatStateParserFactory());
 	//addFactory(new DelayParserFactory());
 	addFactory(new MUCUserPayloadParserFactory(this));
 	addFactory(new MUCOwnerPayloadParserFactory(this));

--- a/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import com.isode.stroke.serializer.GenericPayloadSerializer;

--- a/src/com/isode/stroke/serializer/payloadserializers/ChatStateSerializer.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/ChatStateSerializer.java
@@ -1,0 +1,38 @@
+package com.isode.stroke.serializer.payloadserializers;
+
+import com.isode.stroke.serializer.GenericPayloadSerializer;
+import com.isode.stroke.elements.ChatState;
+import com.isode.stroke.base.NotNull;
+
+public class ChatStateSerializer extends GenericPayloadSerializer<ChatState> {
+
+	/**
+	* CapsInfoSerializer();
+	*/
+	public ChatStateSerializer() {
+		super(ChatState.class);
+	}
+
+	/**
+	* @param chatState, notnull
+	*/
+	@Override
+	protected String serializePayload(ChatState chatState) {
+		NotNull.exceptIfNull(chatState, "chatState");
+		String result = "<";
+		ChatState.ChatStateType stat = chatState.getChatState();
+		if(stat == ChatState.ChatStateType.Active) {
+			result = result.concat("active");
+		} else if (stat == ChatState.ChatStateType.Composing) {
+			result = result.concat("composing");
+		} else if (stat == ChatState.ChatStateType.Paused) {
+			result = result.concat("paused");
+		} else if (stat == ChatState.ChatStateType.Inactive) {
+			result = result.concat("inactive");	
+		} else if (stat == ChatState.ChatStateType.Gone) {
+			result = result.concat("gone");
+		}
+		result = result.concat(" xmlns=\"http://jabber.org/protocol/chatstates\"/>");
+		return result;
+	}
+} 

--- a/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
@@ -23,7 +23,7 @@ public class FullPayloadSerializerCollection extends PayloadSerializerCollection
         //addSerializer(new IBBSerializer());
 	addSerializer(new BodySerializer());
 	addSerializer(new SubjectSerializer());
-	//addSerializer(new ChatStateSerializer());
+	addSerializer(new ChatStateSerializer());
 	//addSerializer(new PrioritySerializer());
 	addSerializer(new ErrorSerializer());
 	addSerializer(new RosterSerializer());

--- a/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
@@ -6,6 +6,11 @@
  * Copyright (c) 2010, Remko Tronçon.
  * All rights reserved.
  */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import com.isode.stroke.serializer.payloadserializers.MUCAdminPayloadSerializer;

--- a/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
+++ b/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import static org.junit.Assert.assertEquals;

--- a/test/com/isode/stroke/serializer/payloadserializers/ChatStateSerializerTest.java
+++ b/test/com/isode/stroke/serializer/payloadserializers/ChatStateSerializerTest.java
@@ -1,0 +1,57 @@
+package com.isode.stroke.serializer.payloadserializers;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import src.com.isode.stroke.elements.ChatState;
+import src.com.isode.stroke.serializer.payloadserializers.ChatStateSerializer;
+
+public class ChatStateSerializerTest {
+
+	ChatStateSerializer testling = new ChatStateSerializer();
+	
+	@Test
+	public void testSerialize() {
+		testGoneState();
+		testComposingState();
+		testPausedState();
+		testInactiveState();
+		testActiveState();
+	}
+
+	@Test
+	void testGoneState() {
+		ChatState priority = new ChatState(ChatState.ChatStateType.Gone);
+		String expected = "<gone xmlns=\"http://jabber.org/protocol/chatstates\"/>";
+		assertEquals(expected, testling.serialize(priority));
+	}
+
+	@Test
+	void testComposingState() {
+		ChatState priority = new ChatState(ChatState.ChatStateType.Composing);
+		String expected = "<composing xmlns=\"http://jabber.org/protocol/chatstates\"/>";
+		assertEquals(expected, testling.serialize(priority));
+	}
+
+	@Test
+	void testPausedState() {
+		ChatState priority = new ChatState(ChatState.ChatStateType.Paused);
+		String expected = "<paused xmlns=\"http://jabber.org/protocol/chatstates\"/>";
+		assertEquals(expected, testling.serialize(priority));
+	}
+
+	@Test
+	void testInactiveState() {
+		ChatState priority = new ChatState(ChatState.ChatStateType.Inactive);
+		String expected = "<inactive xmlns=\"http://jabber.org/protocol/chatstates\"/>";
+		assertEquals(expected, testling.serialize(priority));
+	}
+
+	@Test
+	void testActiveState() {
+		ChatState priority = new ChatState(ChatState.ChatStateType.Active);
+		String expected = "<active xmlns=\"http://jabber.org/protocol/chatstates\"/>";
+		assertEquals(expected, testling.serialize(priority));	
+	}
+}


### PR DESCRIPTION
Adds the Element, Parser, Serializer, ChatStateTracker and ChatStateSerializerTest

License:
This patch is BSD-licensed, see Documentation/Licenses/BSD-simplified.txt for details.

Test-Information:
Ported serializer test from Swiften, which passes.
