### PR TITLE
Add Copyright Information for CapsInfo

### DIFF
--- a/src/com/isode/stroke/elements/CapsInfo.java
+++ b/src/com/isode/stroke/elements/CapsInfo.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.elements;
 
 import com.isode.stroke.base.NotNull;

--- a/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
+++ b/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.parser.payloadparsers;
 
 import com.isode.stroke.parser.GenericPayloadParser;

--- a/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
+++ b/src/com/isode/stroke/parser/payloadparsers/FullPayloadParserFactoryCollection.java
@@ -6,6 +6,11 @@
  * Copyright (c) 2010, Remko Tronçon.
  * All rights reserved.
  */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.parser.payloadparsers;
 
 import com.isode.stroke.parser.GenericPayloadParserFactory;

--- a/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import com.isode.stroke.serializer.GenericPayloadSerializer;

--- a/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/FullPayloadSerializerCollection.java
@@ -6,6 +6,10 @@
  * Copyright (c) 2010, Remko Tronçon.
  * All rights reserved.
  */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
 package com.isode.stroke.serializer.payloadserializers;
 
 import com.isode.stroke.serializer.payloadserializers.MUCAdminPayloadSerializer;

--- a/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
+++ b/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
@@ -1,11 +1,21 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015, Tarun Gupta.
+ * All rights reserved.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import src.com.isode.stroke.elements.CapsInfo;
-import src.com.isode.stroke.serializer.payloadserializers.CapsInfoSerializer;
+import com.isode.stroke.elements.CapsInfo;
+import com.isode.stroke.serializer.payloadserializers.CapsInfoSerializer;
 
 public class CapsInfoSerializerTest {
 


### PR DESCRIPTION
License:
This patch is BSD-licensed, see Documentation/Licenses/BSD-simplified.txt for details.
