### PR TITLE
Add Copyright Information for CapsInfo.

### DIFF
--- a/src/com/isode/stroke/elements/CapsInfo.java
+++ b/src/com/isode/stroke/elements/CapsInfo.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015 Tarun Gupta.
+ * Licensed under the simplified BSD license.
+ * See Documentation/Licenses/BSD-simplified.txt for more information.
+ */
+
 package com.isode.stroke.elements;
 
 import com.isode.stroke.base.NotNull;

--- a/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
+++ b/src/com/isode/stroke/parser/payloadparsers/CapsInfoParser.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015 Tarun Gupta.
+ * Licensed under the simplified BSD license.
+ * See Documentation/Licenses/BSD-simplified.txt for more information.
+ */
+
 package com.isode.stroke.parser.payloadparsers;
 
 import com.isode.stroke.parser.GenericPayloadParser;

--- a/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
+++ b/src/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializer.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015 Tarun Gupta.
+ * Licensed under the simplified BSD license.
+ * See Documentation/Licenses/BSD-simplified.txt for more information.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import com.isode.stroke.serializer.GenericPayloadSerializer;

--- a/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
+++ b/test/com/isode/stroke/serializer/payloadserializers/CapsInfoSerializerTest.java
@@ -1,11 +1,22 @@
+/*
+ * Copyright (c) 2010 Isode Limited.
+ * All rights reserved.
+ * See the COPYING file for more information.
+ */
+/*
+ * Copyright (c) 2015 Tarun Gupta.
+ * Licensed under the simplified BSD license.
+ * See Documentation/Licenses/BSD-simplified.txt for more information.
+ */
+
 package com.isode.stroke.serializer.payloadserializers;
 
 import static org.junit.Assert.assertEquals;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import src.com.isode.stroke.elements.CapsInfo;
-import src.com.isode.stroke.serializer.payloadserializers.CapsInfoSerializer;
+import com.isode.stroke.elements.CapsInfo;
+import com.isode.stroke.serializer.payloadserializers.CapsInfoSerializer;
 
 public class CapsInfoSerializerTest {
 


### PR DESCRIPTION
License:
This patch is BSD-licensed, see Documentation/Licenses/BSD-simplified.txt for details.
